### PR TITLE
Add changes to GenerateCommitMessageService

### DIFF
--- a/Src/AiCommitMessage/Services/GenerateCommitMessageService.cs
+++ b/Src/AiCommitMessage/Services/GenerateCommitMessageService.cs
@@ -50,15 +50,20 @@ public class GenerateCommitMessageService
         // Use the provided message (this will come from the prepare-commit-msg hook)
         string message = options.Message; // No fallback to GIT, as commit message is passed in the hook
 
+        if (string.IsNullOrEmpty(branch) && string.IsNullOrEmpty(diff))
+        {
+            throw new InvalidOperationException("Unable to generate commit message: Both branch and diff are empty.");
+        }
+
         var formattedMessage =
         "Branch: "
-        + branch
+        + (string.IsNullOrEmpty(branch) ? "<unknown>" : branch)
         + "\n\n"
         + "Original message: "
         + message
         + "\n\n"
         + "Git Diff: "
-        + diff;
+        + (string.IsNullOrEmpty(diff) ? "<no changes>" : diff);
 
         var chatCompletion = client.CompleteChat(
             new SystemChatMessage(Constants.SystemMessage),

--- a/Src/AiCommitMessage/Services/GenerateCommitMessageService.cs
+++ b/Src/AiCommitMessage/Services/GenerateCommitMessageService.cs
@@ -9,43 +9,6 @@ using OpenAI.Chat;
 namespace AiCommitMessage.Services;
 
 /// <summary>
-/// Class GitHelper.
-/// </summary>
-public class GitHelper
-{
-    // Retrieves the current branch name
-    public static string GetBranchName()
-    {
-        return ExecuteGitCommand("rev-parse --abbrev-ref HEAD");
-    }
-
-    // Retrieves the staged diff
-    public static string GetGitDiff()
-    {
-        return ExecuteGitCommand("diff --staged");
-    }
-
-    // Executes the provided GIT command and returns the result
-    private static string ExecuteGitCommand(string arguments)
-    {
-        var processStartInfo = new ProcessStartInfo
-        {
-            FileName = "git",
-            Arguments = arguments,
-            RedirectStandardOutput = true,
-            UseShellExecute = false,
-            CreateNoWindow = true,
-        };
-
-        using var process = new Process { StartInfo = processStartInfo };
-        process.Start();
-        var result = process.StandardOutput.ReadToEnd();
-        process.WaitForExit();
-        return result.Trim();
-    }
-}
-
-/// <summary>
 /// Class GenerateCommitMessageService.
 /// </summary>
 public class GenerateCommitMessageService

--- a/Src/AiCommitMessage/Services/GitHelper.cs
+++ b/Src/AiCommitMessage/Services/GitHelper.cs
@@ -1,0 +1,44 @@
+﻿using System.ClientModel;
+using System.Diagnostics;
+using System.Text.Json;
+using AiCommitMessage.Options;
+using AiCommitMessage.Utility;
+using OpenAI;
+using OpenAI.Chat;
+
+/// <summary>
+/// Class GitHelper.
+/// </summary>
+public class GitHelper
+{
+    // Retrieves the current branch name
+    public static string GetBranchName()
+    {
+        return ExecuteGitCommand("rev-parse --abbrev-ref HEAD");
+    }
+
+    // Retrieves the staged diff
+    public static string GetGitDiff()
+    {
+        return ExecuteGitCommand("diff --staged");
+    }
+
+    // Executes the provided GIT command and returns the result
+    private static string ExecuteGitCommand(string arguments)
+    {
+        var processStartInfo = new ProcessStartInfo
+        {
+            FileName = "git",
+            Arguments = arguments,
+            RedirectStandardOutput = true,
+            UseShellExecute = false,
+            CreateNoWindow = true,
+        };
+
+        using var process = new Process { StartInfo = processStartInfo };
+        process.Start();
+        var result = process.StandardOutput.ReadToEnd();
+        process.WaitForExit();
+        return result.Trim();
+    }
+}


### PR DESCRIPTION
<!-- Thanks for creating this pull request 🤗

Please limit this PR to a single type (docs, feature, etc.) and keep it as focused as possible. 
You can create multiple PRs instead of one large one. 
-->

<!-- Closes #IssueNumber -->
Closes #87

## 📑 Description
This PR modifies the behavior of `GenerateCommitMessageService` to automatically retrieve Git branch and diff information if not provided as inputs. This improvement enhances flexibility by allowing the tool to operate without external inputs while keeping existing input options as fallbacks for backward compatibility.

## 🔍 Changes
- [x] Added `GitHelper.GetBranchName()` to retrieve the current Git branch.
- [x] Added `GitHelper.GetGitDiff()` to retrieve the current staged diff.
- [x] Modified `GenerateCommitMessage` to use retrieved values if inputs are empty.

## ✅ Checks
- [x] Code adheres to the project’s style
- [x] Documentation updated if required
- [x] Tests pass successfully

## ☢️ Breaking Changes
<!-- Does this PR introduce breaking changes? If so, mention the impact and possible migration steps -->
- [ ] Yes
- [x] No

## ℹ Additional Information
These changes increase flexibility without introducing any breaking changes. The `GitHelper` class methods may need unit tests to ensure they handle edge cases, such as invalid or empty Git repositories.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new helper for improved Git command execution, enhancing the commit message generation process.
	- Automatically retrieves the current branch name and staged changes for more accurate commit messages.

- **Bug Fixes**
	- Improved logic for generating commit messages by centralizing branch and diff retrieval.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->