### PR TITLE
fix - fix install hook exception and update test SDK version +semver: minor

### DIFF
--- a/Src/AiCommitMessage/Services/InstallHookService.cs
+++ b/Src/AiCommitMessage/Services/InstallHookService.cs
@@ -26,7 +26,6 @@ internal static class InstallHookService
         if (string.IsNullOrWhiteSpace(options.Path))
         {
             directory = Path.Combine(GetGitRepositoryRootLevel(), GetHooksDirectory());
-            EnsureDirectoryExists(directory);
         }
 
         var hookPath = Path.Combine(directory, "prepare-commit-msg");
@@ -190,7 +189,7 @@ internal static class InstallHookService
         string file
     )
     {
-        EnsureDirectoryExists(outputDir);
+        EnsureDirectoryExists(Path.Combine(outputDir, file));
         using var stream = typeof(InstallHookService).Assembly.GetManifestResourceStream(
             resourceLocation + "." + file
         );
@@ -219,7 +218,7 @@ internal static class InstallHookService
     private static void EnsureDirectoryExists(string path)
     {
         var directoryName = Path.GetDirectoryName(path);
-        if (directoryName is { Length: > 0 })
+        if (directoryName is { Length: > 0 } && !Directory.Exists(directoryName))
         {
             Directory.CreateDirectory(directoryName);
         }

--- a/Tests/AiCommitMessage.Tests/AiCommitMessage.Tests.csproj
+++ b/Tests/AiCommitMessage.Tests/AiCommitMessage.Tests.csproj
@@ -15,7 +15,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="FluentAssertions" Version="6.12.2" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
     <PackageReference Include="NSubstitute" Version="5.3.0" />
     <PackageReference Include="xunit" Version="2.9.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">


### PR DESCRIPTION
## 📑 Description
Fix the `install-hook` command when the directory does not exists.

## ✅ Checks
- [X] My pull request adheres to the code style of this project
- [X] My code requires changes to the documentation
- [X] I have updated the documentation as required
- [X] All the tests have passed

## ☢️ Does this introduce a breaking change?
- [ ] Yes
- [X] No

## ℹ Additional Information
Update tests SDK package

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Improved directory management and resource extraction processes for enhanced robustness.
  
- **Bug Fixes**
	- Fixed issues related to unnecessary directory creation attempts during resource extraction.

- **Chores**
	- Updated the `Microsoft.NET.Test.Sdk` package to the latest version for improved testing capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->