### PR TITLE
Add support for -skipai flag to bypass AI commit generation

### DIFF
--- a/Src/AiCommitMessage/Services/GenerateCommitMessageService.cs
+++ b/Src/AiCommitMessage/Services/GenerateCommitMessageService.cs
@@ -27,6 +27,22 @@ public class GenerateCommitMessageService
     );
 
     /// <summary>
+    /// Regular expression to detect the presence of the "-skipai" flag in commit messages.
+    /// </summary>
+    private static readonly Regex SkipAIFlagPattern = new(
+        @" -skipai$",
+        RegexOptions.Compiled | RegexOptions.CultureInvariant | RegexOptions.IgnoreCase,
+        TimeSpan.FromMilliseconds(100)
+    );
+
+    /// <summary>
+    /// Represents the length of the flag used to skip AI processing.
+    /// </summary>
+    /// <remarks>This constant defines the number of bits or characters used to represent the skip AI flag. It
+    /// is intended for internal use and should not be modified.</remarks>
+    private const int SkipAIFlagLength = 8;
+
+    /// <summary>
     /// Checks whether the given commit message is a merge conflict resolution message.
     /// </summary>
     /// <param name="message">The commit message to evaluate.</param>
@@ -54,11 +70,16 @@ public class GenerateCommitMessageService
             ? GitHelper.GetBranchName()
             : options.Branch;
         var diff = string.IsNullOrEmpty(options.Diff) ? GitHelper.GetGitDiff() : options.Diff;
-        var message = options.Message;
+        var message = options.Message.Trim();
 
         if (IsMergeConflictResolution(message))
         {
             return message;
+        }
+
+        if (HasSkipAIFlag(message))
+        {
+            return message[..^SkipAIFlagLength];
         }
 
         if (Encoding.UTF8.GetByteCount(diff) > 10240)
@@ -88,6 +109,15 @@ public class GenerateCommitMessageService
         var model = EnvironmentLoader.LoadModelName();
         return GenerateWithModel(model, formattedMessage, branch, message, options.Debug);
     }
+
+    /// <summary>
+    /// Determines whether the specified message contains the "Skip AI" flag.
+    /// </summary>
+    /// <remarks>The "Skip AI" flag is identified using a predefined pattern. This method is case-sensitive
+    /// and matches the pattern exactly as defined.</remarks>
+    /// <param name="message">The message to check for the presence of the "Skip AI" flag. Cannot be null.</param>
+    /// <returns><see langword="true"/> if the message contains the "Skip AI" flag; otherwise, <see langword="false"/>.</returns>
+    private static bool HasSkipAIFlag(string message) => SkipAIFlagPattern.IsMatch(message);
 
     /// <summary>
     /// Generates a commit message using the specified model.

--- a/Tests/AiCommitMessage.Tests/Services/GenerateCommitMessageServiceTests.cs
+++ b/Tests/AiCommitMessage.Tests/Services/GenerateCommitMessageServiceTests.cs
@@ -13,9 +13,9 @@ public class GenerateCommitMessageServiceTests
 
     public GenerateCommitMessageServiceTests()
     {
-        Environment.SetEnvironmentVariable("OPENAI_API_KEY", "test");
+        Environment.SetEnvironmentVariable("OPENAI_API_KEY", "test", EnvironmentVariableTarget.User);
         //_mockChatClient = Substitute.For<ChatClient>(
-        //    "model-name",
+        //    "model-name", 
         //    new ApiKeyCredential("key"),
         //    Substitute.For<OpenAIClientOptions>()
         //);
@@ -82,108 +82,135 @@ public class GenerateCommitMessageServiceTests
             );
     }
 
-    //[Fact]
-    //public void GenerateCommitMessage_Should_IncludeBranchAndDiff_When_Provided()
-    //{
-    //    // Arrange
-    //    var options = new GenerateCommitMessageOptions
-    //    {
-    //        Branch = "feature/test",
-    //        Diff = "Added new feature",
-    //        Message = "Initial commit"
-    //    };
+    [Fact]
+    public void GenerateCommitMessage_Should_ByPass_ApiCalls_When_SkipAI_Flag_Is_Provided()
+    {
+        // Arrange
+        var options = new GenerateCommitMessageOptions
+        {
+            Branch = "feature/test",
+            Diff = "Some diff",
+            Message = "Initial commit -skipai ",
+        };
+        var result = _service.GenerateCommitMessage(options);
+        result.Should().Be("Initial commit");
+    }
 
-    //    _mockChatClient.CompleteChat(Arg.Any<SystemChatMessage>(), Arg.Any<UserChatMessage>())
-    //        .Returns(new ChatCompletionResult
-    //        {
-    //            Value = new ChatCompletion
-    //            {
-    //                Content = new[] { new ChatMessage { Text = "Generated commit message" } }
-    //            }
-    //        });
+    [Fact]
+    public void GenerateCommitMessage_Should_Ignore_SkipAI_Flag_When_SKipAI_Flag_Is_Misplaced()
+    {
+        // Arrange
+        var options = new GenerateCommitMessageOptions
+        {
+            Branch = "feature/test",
+            Diff = "Some diff",
+            Message = "Test misplaced -skipai commit",
+        };
+        var result = _service.GenerateCommitMessage(options);
+        result.Should().NotBe("Test misplaced -skipai commit");
+    }
+        //[Fact]
+        //public void GenerateCommitMessage_Should_IncludeBranchAndDiff_When_Provided()
+        //{
+        //    // Arrange
+        //    var options = new GenerateCommitMessageOptions
+        //    {
+        //        Branch = "feature/test",
+        //        Diff = "Added new feature",
+        //        Message = "Initial commit"
+        //    };
 
-    //    // Act
-    //    var result = _service.GenerateCommitMessage(options);
+        //    _mockChatClient.CompleteChat(Arg.Any<SystemChatMessage>(), Arg.Any<UserChatMessage>())
+        //        .Returns(new ChatCompletionResult
+        //        {
+        //            Value = new ChatCompletion
+        //            {
+        //                Content = new[] { new ChatMessage { Text = "Generated commit message" } }
+        //            }
+        //        });
 
-    //    // Assert
-    //    result.Should().Contain("Branch: feature/test");
-    //    result.Should().Contain("Original message: Initial commit");
-    //    result.Should().Contain("Git Diff: Added new feature");
-    //}
+        //    // Act
+        //    var result = _service.GenerateCommitMessage(options);
 
-    //[Fact]
-    //public void GenerateCommitMessage_Should_DebugOutputToFile_When_DebugIsEnabled()
-    //{
-    //    // Arrange
-    //    var options = new GenerateCommitMessageOptions
-    //    {
-    //        Branch = "feature/test",
-    //        Diff = "Some diff",
-    //        Message = "Initial commit",
-    //        Debug = true
-    //    };
+        //    // Assert
+        //    result.Should().Contain("Branch: feature/test");
+        //    result.Should().Contain("Original message: Initial commit");
+        //    result.Should().Contain("Git Diff: Added new feature");
+        //}
 
-    //    var chatCompletionResult = new ChatCompletionResult
-    //    {
-    //        Value = new ChatCompletion
-    //        {
-    //            Content = new[] { new ChatMessage { Text = "Generated commit message" } }
-    //        }
-    //    };
+        //[Fact]
+        //public void GenerateCommitMessage_Should_DebugOutputToFile_When_DebugIsEnabled()
+        //{
+        //    // Arrange
+        //    var options = new GenerateCommitMessageOptions
+        //    {
+        //        Branch = "feature/test",
+        //        Diff = "Some diff",
+        //        Message = "Initial commit",
+        //        Debug = true
+        //    };
 
-    //    _mockChatClient.CompleteChat(Arg.Any<SystemChatMessage>(), Arg.Any<UserChatMessage>())
-    //        .Returns(chatCompletionResult);
+        //    var chatCompletionResult = new ChatCompletionResult
+        //    {
+        //        Value = new ChatCompletion
+        //        {
+        //            Content = new[] { new ChatMessage { Text = "Generated commit message" } }
+        //        }
+        //    };
 
-    //    // Act
-    //    var result = _service.GenerateCommitMessage(options);
+        //    _mockChatClient.CompleteChat(Arg.Any<SystemChatMessage>(), Arg.Any<UserChatMessage>())
+        //        .Returns(chatCompletionResult);
 
-    //    // Assert
-    //    result.Should().Be("Generated commit message");
-    //    var debugFileContent = File.ReadAllText("debug.json");
-    //    debugFileContent.Should().Be(JsonSerializer.Serialize(chatCompletionResult));
-    //}
+        //    // Act
+        //    var result = _service.GenerateCommitMessage(options);
 
-    //     [Fact]
-    //     public void GenerateCommitMessage_WithLlamaModel_Should_MatchExpectedPattern()
-    //     {
-    //         // Arrange
-    //         Environment.SetEnvironmentVariable("AI_MODEL", "llama-3-1-405B-Instruct");
-    //         var options = new GenerateCommitMessageOptions
-    //         {
-    //             Branch = "feature/llama",
-    //             Diff = "Add llama-specific functionality",
-    //             Message = "Initial llama commit",
-    //         };
+        //    // Assert
+        //    result.Should().Be("Generated commit message");
+        //    var debugFileContent = File.ReadAllText("debug.json");
+        //    debugFileContent.Should().Be(JsonSerializer.Serialize(chatCompletionResult));
+        //}
 
-    //         // Act
-    //         var result = _service.GenerateCommitMessage(options);
+        //     [Fact]
+        //     public void GenerateCommitMessage_WithLlamaModel_Should_MatchExpectedPattern()
+        //     {
+        //         // Arrange
+        //         Environment.SetEnvironmentVariable("AI_MODEL", "llama-3-1-405B-Instruct");
+        //         var options = new GenerateCommitMessageOptions
+        //         {
+        //             Branch = "feature/llama",
+        //             Diff = "Add llama-specific functionality",
+        //             Message = "Initial llama commit",
+        //         };
 
-    //         // Assert
-    //         result.Should().MatchRegex("(?i)(?=.*add)(?=.*llama)");
-    //     }
+        //         // Act
+        //         var result = _service.GenerateCommitMessage(options);
 
-    //     [Fact]
-    //     public void GenerateCommitMessage_WithGPTModel_Should_MatchExpectedPattern()
-    //     {
-    //         // Arrange
-    //         Environment.SetEnvironmentVariable(
-    //             "AI_MODEL",
-    //             "gpt-4o-mini",
-    //             EnvironmentVariableTarget.User
-    //         );
+        //         // Assert
+        //         result.Should().MatchRegex("(?i)(?=.*add)(?=.*llama)");
+        //     }
 
-    //         var service = new GenerateCommitMessageService();
-    //         var options = new GenerateCommitMessageOptions
-    //         {
-    //             Branch = "feature/gpt",
-    //             Diff = "Add GPT-specific improvements",
-    //             Message = "Initial GPT commit",
-    //         };
+        //     [Fact]
+        //     public void GenerateCommitMessage_WithGPTModel_Should_MatchExpectedPattern()
+        //     {
+        //         // Arrange
+        //         Environment.SetEnvironmentVariable(
+        //             "AI_MODEL",
+        //             "gpt-4o-mini",
+        //             EnvironmentVariableTarget.User
+        //         );
 
-    //         // Act
-    //         var result = service.GenerateCommitMessage(options);
+        //         var service = new GenerateCommitMessageService();
+        //         var options = new GenerateCommitMessageOptions
+        //         {
+        //             Branch = "feature/gpt",
+        //             Diff = "Add GPT-specific improvements",
+        //             Message = "Initial GPT commit",
+        //         };
 
-    //         // Assert
-    //         result.Should().MatchRegex("(?i)(?=.*add)(?=.*gpt)");
-    //     }
-}
+        //         // Act
+        //         var result = service.GenerateCommitMessage(options);
+
+        //         // Assert
+        //         result.Should().MatchRegex("(?i)(?=.*add)(?=.*gpt)");
+        //     }
+    }


### PR DESCRIPTION
<!-- 
Thanks for creating this pull request 🤗

Please limit the pull request to one type (docs, feature, etc.) and keep it as small as possible. 
You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below -->
Closes #250 

## 📑 Description
<!-- Add a brief description of the pr -->
Introduces a '-skipai' flag that, when present at the end of a commit message, bypasses AI-based commit message generation and returns the original message without the flag. Includes new tests to verify correct handling of the flag and ensures misplaced flags do not trigger bypass.

<!-- 
You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and check the following fields as needed -->
- [x] My pull request adheres to the code style of this project
- [x] My code requires changes to the documentation
- [x] I have updated the documentation as required
- [x] All the tests have passed

## ☢️ Does this introduce a breaking change?
<!-- If this introduces a breaking change, make sure to note it here and what the impact might be -->
- [ ] Yes
- [X] No
