### PR TITLE
[BUG] Do not include JIRA ticket or GitHub issue number twice in the commit message

### DIFF
--- a/Src/AiCommitMessage/Services/GenerateCommitMessageService.cs
+++ b/Src/AiCommitMessage/Services/GenerateCommitMessageService.cs
@@ -323,18 +323,14 @@ public class GenerateCommitMessageService
         if (provider == GitProvider.GitHub)
         {
             var issueNumber = BranchNameUtility.ExtractIssueNumber(branch);
-            if (!string.IsNullOrWhiteSpace(issueNumber))
-            {
-                if (
-                    !Regex.IsMatch(
+            if (!string.IsNullOrWhiteSpace(issueNumber) && !Regex.IsMatch(
                         text,
                         $@"^#?{Regex.Escape(issueNumber)}\b",
-                        RegexOptions.IgnoreCase
-                    )
-                )
-                {
-                    text = $"#{issueNumber} {text}";
-                }
+                        RegexOptions.Compiled | RegexOptions.CultureInvariant | RegexOptions.IgnoreCase,
+                        TimeSpan.FromSeconds(5)
+                    ))
+            {
+                text = $"#{issueNumber} {text}";
             }
         }
         else
@@ -345,7 +341,8 @@ public class GenerateCommitMessageService
                 var normalizedPrefix = Regex.Escape(jiraTicketNumber).Replace("-", "[-_\\s]*");
                 var jiraRegex = new Regex(
                     $"^\\[?{normalizedPrefix}\\]?",
-                    RegexOptions.IgnoreCase | RegexOptions.CultureInvariant
+                    RegexOptions.Compiled | RegexOptions.CultureInvariant | RegexOptions.IgnoreCase,
+                    TimeSpan.FromSeconds(5)
                 );
 
                 if (!jiraRegex.IsMatch(text))

--- a/Src/AiCommitMessage/Services/GenerateCommitMessageService.cs
+++ b/Src/AiCommitMessage/Services/GenerateCommitMessageService.cs
@@ -325,7 +325,13 @@ public class GenerateCommitMessageService
             var issueNumber = BranchNameUtility.ExtractIssueNumber(branch);
             if (!string.IsNullOrWhiteSpace(issueNumber))
             {
-                if (!Regex.IsMatch(text, $@"^#?{Regex.Escape(issueNumber)}\b", RegexOptions.IgnoreCase))
+                if (
+                    !Regex.IsMatch(
+                        text,
+                        $@"^#?{Regex.Escape(issueNumber)}\b",
+                        RegexOptions.IgnoreCase
+                    )
+                )
                 {
                     text = $"#{issueNumber} {text}";
                 }
@@ -341,7 +347,7 @@ public class GenerateCommitMessageService
                     $"^\\[?{normalizedPrefix}\\]?",
                     RegexOptions.IgnoreCase | RegexOptions.CultureInvariant
                 );
-    
+
                 if (!jiraRegex.IsMatch(text))
                 {
                     text = $"[{jiraTicketNumber}] {text}";

--- a/Src/AiCommitMessage/Services/GenerateCommitMessageService.cs
+++ b/Src/AiCommitMessage/Services/GenerateCommitMessageService.cs
@@ -338,8 +338,7 @@ public class GenerateCommitMessageService
             }
         }
 
-
-        if(provider != GitProvider.GitHub || string.IsNullOrWhiteSpace(issueNumber))
+        if (provider != GitProvider.GitHub || string.IsNullOrWhiteSpace(issueNumber))
         {
             var jiraTicketNumber = BranchNameUtility.ExtractJiraTicket(branch);
             if (!string.IsNullOrWhiteSpace(jiraTicketNumber))

--- a/Src/AiCommitMessage/Services/GenerateCommitMessageService.cs
+++ b/Src/AiCommitMessage/Services/GenerateCommitMessageService.cs
@@ -80,7 +80,7 @@ public class GenerateCommitMessageService
 
         if (HasSkipAIFlag(message))
         {
-            message = message[..^SkipAIFlag.Length];
+            message = message[..^SkipAIFlag.Length].Trim();
             return PostProcess(message, branch, message);
         }
 

--- a/Src/AiCommitMessage/Services/GenerateCommitMessageService.cs
+++ b/Src/AiCommitMessage/Services/GenerateCommitMessageService.cs
@@ -320,9 +320,10 @@ public class GenerateCommitMessageService
     private static string PostProcess(string text, string branch, string message)
     {
         var provider = GetGitProvider();
+        var issueNumber = string.Empty;
         if (provider == GitProvider.GitHub)
         {
-            var issueNumber = BranchNameUtility.ExtractIssueNumber(branch);
+            issueNumber = BranchNameUtility.ExtractIssueNumber(branch);
             if (
                 !string.IsNullOrWhiteSpace(issueNumber)
                 && !Regex.IsMatch(
@@ -336,7 +337,9 @@ public class GenerateCommitMessageService
                 text = $"#{issueNumber} {text}";
             }
         }
-        else
+
+
+        if(provider != GitProvider.GitHub || string.IsNullOrWhiteSpace(issueNumber))
         {
             var jiraTicketNumber = BranchNameUtility.ExtractJiraTicket(branch);
             if (!string.IsNullOrWhiteSpace(jiraTicketNumber))

--- a/Src/AiCommitMessage/Services/GenerateCommitMessageService.cs
+++ b/Src/AiCommitMessage/Services/GenerateCommitMessageService.cs
@@ -323,12 +323,15 @@ public class GenerateCommitMessageService
         if (provider == GitProvider.GitHub)
         {
             var issueNumber = BranchNameUtility.ExtractIssueNumber(branch);
-            if (!string.IsNullOrWhiteSpace(issueNumber) && !Regex.IsMatch(
-                        text,
-                        $@"^#?{Regex.Escape(issueNumber)}\b",
-                        RegexOptions.Compiled | RegexOptions.CultureInvariant | RegexOptions.IgnoreCase,
-                        TimeSpan.FromSeconds(5)
-                    ))
+            if (
+                !string.IsNullOrWhiteSpace(issueNumber)
+                && !Regex.IsMatch(
+                    text,
+                    $@"^#?{Regex.Escape(issueNumber)}\b",
+                    RegexOptions.Compiled | RegexOptions.CultureInvariant | RegexOptions.IgnoreCase,
+                    TimeSpan.FromSeconds(5)
+                )
+            )
             {
                 text = $"#{issueNumber} {text}";
             }

--- a/Tests/AiCommitMessage.Tests/Services/GenerateCommitMessageServiceTests.cs
+++ b/Tests/AiCommitMessage.Tests/Services/GenerateCommitMessageServiceTests.cs
@@ -94,7 +94,7 @@ public class GenerateCommitMessageServiceTests
             Diff = "Some diff",
             Message = "Initial commit -skipai",
         };
-        
+
         //Act
         var result = _service.GenerateCommitMessage(options);
 
@@ -130,7 +130,7 @@ public class GenerateCommitMessageServiceTests
             Diff = "Some diff",
             Message = "Initial commit -skipai",
         };
-        
+
         //Act
         var result = _service.GenerateCommitMessage(options);
 

--- a/Tests/AiCommitMessage.Tests/Services/GenerateCommitMessageServiceTests.cs
+++ b/Tests/AiCommitMessage.Tests/Services/GenerateCommitMessageServiceTests.cs
@@ -85,7 +85,25 @@ public class GenerateCommitMessageServiceTests
     }
 
     [Fact]
-    public void GenerateCommitMessage_Should_Not_Duplicate_JIRA_prefix_and_Skip_AI()
+    public void GenerateCommitMessage_Should_Add_GitHub_issue_number_and_Skip_AI()
+    {
+        // Arrange
+        var options = new GenerateCommitMessageOptions
+        {
+            Branch = "feature/123-my-branch-name",
+            Diff = "Some diff",
+            Message = "Initial commit -skipai",
+        };
+        
+        //Act
+        var result = _service.GenerateCommitMessage(options);
+
+        // Assert
+        result.Should().Be("#123 Initial commit");
+    }
+
+    [Fact]
+    public void GenerateCommitMessage_Should_Not_Duplicate_GitHub_issue_number_and_Skip_AI()
     {
         // Arrange
         var options = new GenerateCommitMessageOptions
@@ -94,7 +112,11 @@ public class GenerateCommitMessageServiceTests
             Diff = "Some diff",
             Message = "#123 Initial commit -skipai",
         };
+
+        //Act
         var result = _service.GenerateCommitMessage(options);
+
+        // Assert
         result.Should().Be("#123 Initial commit");
     }
 

--- a/Tests/AiCommitMessage.Tests/Services/GenerateCommitMessageServiceTests.cs
+++ b/Tests/AiCommitMessage.Tests/Services/GenerateCommitMessageServiceTests.cs
@@ -120,6 +120,42 @@ public class GenerateCommitMessageServiceTests
         result.Should().Be("#123 Initial commit");
     }
 
+    [Fact]
+    public void GenerateCommitMessage_Should_Add_JIRA_prefix_and_Skip_AI()
+    {
+        // Arrange
+        var options = new GenerateCommitMessageOptions
+        {
+            Branch = "feature/TEST-123-my-branch-name",
+            Diff = "Some diff",
+            Message = "Initial commit -skipai",
+        };
+        
+        //Act
+        var result = _service.GenerateCommitMessage(options);
+
+        // Assert
+        result.Should().Be("[TEST-123] Initial commit");
+    }
+
+    [Fact]
+    public void GenerateCommitMessage_Should_Not_Duplicate_JIRA_prefix_and_Skip_AI()
+    {
+        // Arrange
+        var options = new GenerateCommitMessageOptions
+        {
+            Branch = "feature/TEST-123-my-branch-name",
+            Diff = "Some diff",
+            Message = "[TEST-123] Initial commit -skipai",
+        };
+
+        //Act
+        var result = _service.GenerateCommitMessage(options);
+
+        // Assert
+        result.Should().Be("[TEST-123] Initial commit");
+    }
+
     /// <summary>
     /// Tests that API calls are bypassed when the SkipAI flag is provided in the options.
     /// </summary>

--- a/Tests/AiCommitMessage.Tests/Services/GenerateCommitMessageServiceTests.cs
+++ b/Tests/AiCommitMessage.Tests/Services/GenerateCommitMessageServiceTests.cs
@@ -95,7 +95,7 @@ public class GenerateCommitMessageServiceTests
             Message = "#123 Initial commit -skipai",
         };
         var result = _service.GenerateCommitMessage(options);
-        result.Should().Be("#123 - Initial commit");
+        result.Should().Be("#123 Initial commit");
     }
 
     /// <summary>

--- a/Tests/AiCommitMessage.Tests/Services/GenerateCommitMessageServiceTests.cs
+++ b/Tests/AiCommitMessage.Tests/Services/GenerateCommitMessageServiceTests.cs
@@ -84,6 +84,20 @@ public class GenerateCommitMessageServiceTests
             );
     }
 
+    [Fact]
+    public void GenerateCommitMessage_Should_Not_Duplicate_JIRA_prefix()
+    {
+        // Arrange
+        var options = new GenerateCommitMessageOptions
+        {
+            Branch = "feature/TEST-123-my-branch-name",
+            Diff = "Some diff",
+            Message = "[TEST-123] Initial commit",
+        };
+        var result = _service.GenerateCommitMessage(options);
+        result.Should().Be("[TEST-123] Initial commit");
+    }
+
     /// <summary>
     /// Tests that API calls are bypassed when the SkipAI flag is provided in the options.
     /// </summary>

--- a/Tests/AiCommitMessage.Tests/Services/GenerateCommitMessageServiceTests.cs
+++ b/Tests/AiCommitMessage.Tests/Services/GenerateCommitMessageServiceTests.cs
@@ -90,12 +90,12 @@ public class GenerateCommitMessageServiceTests
         // Arrange
         var options = new GenerateCommitMessageOptions
         {
-            Branch = "feature/TEST-123-my-branch-name",
+            Branch = "feature/123-my-branch-name",
             Diff = "Some diff",
-            Message = "[TEST-123] Initial commit",
+            Message = "#123 Initial commit",
         };
         var result = _service.GenerateCommitMessage(options);
-        result.Should().Be("[TEST-123] Initial commit");
+        result.Should().Be("#123 - Initial commit");
     }
 
     /// <summary>

--- a/Tests/AiCommitMessage.Tests/Services/GenerateCommitMessageServiceTests.cs
+++ b/Tests/AiCommitMessage.Tests/Services/GenerateCommitMessageServiceTests.cs
@@ -112,7 +112,7 @@ public class GenerateCommitMessageServiceTests
             Message = "Initial commit -skipai ",
         };
         var result = _service.GenerateCommitMessage(options);
-        result.Should().Be("Initial commit ");
+        result.Should().Be("Initial commit");
     }
 
     /// <summary>

--- a/Tests/AiCommitMessage.Tests/Services/GenerateCommitMessageServiceTests.cs
+++ b/Tests/AiCommitMessage.Tests/Services/GenerateCommitMessageServiceTests.cs
@@ -85,14 +85,14 @@ public class GenerateCommitMessageServiceTests
     }
 
     [Fact]
-    public void GenerateCommitMessage_Should_Not_Duplicate_JIRA_prefix()
+    public void GenerateCommitMessage_Should_Not_Duplicate_JIRA_prefix_and_Skip_AI()
     {
         // Arrange
         var options = new GenerateCommitMessageOptions
         {
             Branch = "feature/123-my-branch-name",
             Diff = "Some diff",
-            Message = "#123 Initial commit",
+            Message = "#123 Initial commit -skipai",
         };
         var result = _service.GenerateCommitMessage(options);
         result.Should().Be("#123 - Initial commit");


### PR DESCRIPTION
### **User description**
## 📑 Description
Do not include JIRA ticket or GitHub issue number twice in the commit message

## ✅ Checks
- [X] My pull request adheres to the code style of this project
- [X] My code requires changes to the documentation
- [X] I have updated the documentation as required
- [X] All the tests have passed

## ☢️ Does this introduce a breaking change?
- [ ] Yes
- [X] No

---


> [!NOTE]
> I'm currently writing a description for your pull request. I should be done shortly (<1 minute). Please don't edit the description field until I'm finished, or we may overwrite each other. If I find nothing to write about, I'll delete this message.


___

### **Description**
- Enhanced the `ProcessGeneratedMessage` method to prevent duplication of JIRA ticket prefixes in commit messages.
- Introduced regex checks to ensure that JIRA ticket numbers are only appended if they are not already present.
- Updated method documentation for better understanding.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>GenerateCommitMessageService.cs</strong><dd><code>Enhance commit message processing to avoid duplicate JIRA prefixes</code></dd></summary>
<hr>

Src/AiCommitMessage/Services/GenerateCommitMessageService.cs
<li>Improved the logic to prevent duplicate JIRA ticket prefixes in commit <br>messages.<br> <li> Added regex checks to ensure JIRA ticket numbers are not appended if <br>already present.<br> <li> Updated method documentation for clarity.<br>


</details>


  </td>
  <td><a href="https://github.com/guibranco/dotnet-aicommitmessage/pull/261/files#diff-be9444b2fa6e271619bfde49a8db5f8b957ffad8f8ff4c43ac702260468c5651">+15/-3</a>&nbsp; &nbsp; </td>
</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **Penify usage**:
>Comment `/help` on the PR to get a list of all available Penify tools and their descriptions



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved commit message generation to avoid duplicate issue or ticket numbers at the start of messages for both GitHub and Jira branches.
  * Ensured commit messages correctly handle flags like `-skipai` by removing them without affecting ticket prefixes.
* **Tests**
  * Added tests to verify correct handling of GitHub and Jira issue prefixes in commit messages when `-skipai` flag is used.
  * Enhanced tests to ensure no duplication of issue or ticket numbers and proper trimming of commit messages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->