### PR TITLE
Update coverage report path for SonarCloud

### DIFF
--- a/.github/workflows/sonar-cloud.yml
+++ b/.github/workflows/sonar-cloud.yml
@@ -61,7 +61,7 @@ jobs:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
           OPENAI_API_KEY : ${{ secrets.OPENAI_API_KEY }}
         run: |
-          ~/.sonar/cache/dotnet-sonarscanner begin /k:"${{ env.KEY }}" /o:"${{ env.ORG }}" /d:sonar.token="${{ secrets.SONAR_TOKEN }}" /d:sonar.host.url="https://sonarcloud.io" /d:sonar.scanner.scanAll=false /d:sonar.cs.opencover.reportsPaths="Tests/**/coverage.net8.0.opencover.xml"
+          ~/.sonar/cache/dotnet-sonarscanner begin /k:"${{ env.KEY }}" /o:"${{ env.ORG }}" /d:sonar.token="${{ secrets.SONAR_TOKEN }}" /d:sonar.host.url="https://sonarcloud.io" /d:sonar.scanner.scanAll=false /d:sonar.cs.opencover.reportsPaths="Tests/**/coverage.net9.0.opencover.xml"
           dotnet build -c Release --verbosity minimal
           dotnet test -c Release --verbosity minimal --no-build --no-restore /p:CollectCoverage=true /p:CoverletOutputFormat="opencover"
           ~/.sonar/cache/dotnet-sonarscanner end /d:sonar.token="${{ secrets.SONAR_TOKEN }}"


### PR DESCRIPTION
### **User description**
## 📑 Description
Update coverage report path for SonarCloud

## ✅ Checks
- [X] My pull request adheres to the code style of this project
- [X] My code requires changes to the documentation
- [X] I have updated the documentation as required
- [X] All the tests have passed

## ☢️ Does this introduce a breaking change?
- [ ] Yes
- [X] No

---


> [!NOTE]
> I'm currently writing a description for your pull request. I should be done shortly (<1 minute). Please don't edit the description field until I'm finished, or we may overwrite each other. If I find nothing to write about, I'll delete this message.


___

### **Description**
- Updated the coverage report path for SonarCloud to reflect the new version.
- Ensured compatibility with .NET 9.0 coverage reports.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>sonar-cloud.yml</strong><dd><code>Update Coverage Report Path for SonarCloud</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/sonar-cloud.yml
<li>Updated the coverage report path for SonarCloud.<br> <li> Changed from <code>coverage.net8.0.opencover.xml</code> to <br><code>coverage.net9.0.opencover.xml</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/guibranco/dotnet-aicommitmessage/pull/264/files#diff-da37722c9e2b4546f672b0e04fbe8f6446b02496d03d5b2491af2fcb534dabf7">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **Penify usage**:
>Comment `/help` on the PR to get a list of all available Penify tools and their descriptions



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the workflow to use coverage reports generated for .NET 9.0 instead of .NET 8.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->