### PR TITLE
feat: add initial commit detection and refactor message building +semver: minor

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -22,5 +22,6 @@
     "sonarlint.connectedMode.project": {
         "connectionId": "guibranco",
         "projectKey": "guibranco_dotnet-aicommitmessage"
-    }
+    },
+    "snyk.advanced.autoSelectOrganization": true
 }

--- a/Src/AiCommitMessage/AiCommitMessage.csproj
+++ b/Src/AiCommitMessage/AiCommitMessage.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net10.0</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>disable</Nullable>
     <PackAsTool>true</PackAsTool>

--- a/Src/AiCommitMessage/Options/GenerateCommitMessageOptions.cs
+++ b/Src/AiCommitMessage/Options/GenerateCommitMessageOptions.cs
@@ -49,4 +49,14 @@ public class GenerateCommitMessageOptions
     /// </remarks>
     [Option('D', "debug", Required = false, HelpText = "Debug mode.")]
     public bool Debug { get; set; }
+
+    /// <summary>
+    /// Gets or sets an override for whether the current commit is the true initial commit.
+    /// </summary>
+    /// <value><c>true</c> or <c>false</c> to override detection; <c>null</c> to detect via git.</value>
+    /// <remarks>
+    /// Not exposed as a CLI option. When <c>null</c>, the value is determined by inspecting
+    /// the repository via <see cref="AiCommitMessage.Utility.GitHelper.IsInitialCommit()"/>.
+    /// </remarks>
+    public bool? IsInitialCommit { get; set; }
 }

--- a/Src/AiCommitMessage/Services/GenerateCommitMessageService.cs
+++ b/Src/AiCommitMessage/Services/GenerateCommitMessageService.cs
@@ -110,15 +110,8 @@ public class GenerateCommitMessageService
             );
         }
 
-        var formattedMessage =
-            "Branch: "
-            + (string.IsNullOrEmpty(branch) ? "<unknown>" : branch)
-            + "\n\n"
-            + "Original message: "
-            + message
-            + "\n\n"
-            + "Git Diff: "
-            + (string.IsNullOrEmpty(diff) ? "<no changes>" : diff);
+        var isInitialCommit = options.IsInitialCommit ?? GitHelper.IsInitialCommit();
+        var formattedMessage = BuildFormattedMessage(branch, diff, message, isInitialCommit);
 
         var model = EnvironmentLoader.LoadModelName();
 
@@ -133,6 +126,35 @@ public class GenerateCommitMessageService
             );
             return PostProcess(message, branch, message);
         }
+    }
+
+    /// <summary>
+    /// Builds the prompt content describing the branch, initial-commit status, draft message,
+    /// and diff that is sent to the AI model.
+    /// </summary>
+    /// <param name="branch">The branch name.</param>
+    /// <param name="diff">The staged git diff.</param>
+    /// <param name="message">The user's draft commit message.</param>
+    /// <param name="isInitialCommit">Whether the commit being prepared is the true initial commit (no parent).</param>
+    /// <returns>The formatted prompt content.</returns>
+    internal static string BuildFormattedMessage(
+        string branch,
+        string diff,
+        string message,
+        bool isInitialCommit
+    )
+    {
+        return "Branch: "
+            + (string.IsNullOrEmpty(branch) ? "<unknown>" : branch)
+            + "\n\n"
+            + "Is initial commit: "
+            + (isInitialCommit ? "true" : "false")
+            + "\n\n"
+            + "Original message: "
+            + message
+            + "\n\n"
+            + "Git Diff: "
+            + (string.IsNullOrEmpty(diff) ? "<no changes>" : diff);
     }
 
     private static string FilterPackageLockDiff(string diff)

--- a/Src/AiCommitMessage/Utility/Constants.cs
+++ b/Src/AiCommitMessage/Utility/Constants.cs
@@ -11,10 +11,11 @@ public class Constants
     public const string SystemMessage = """
         You are an expert assistant specialized in generating high-quality Git commit messages.
 
-        You receive three inputs:
+        You receive four inputs:
         1. The branch name
-        2. The git diff content
-        3. The user's draft commit message (optional)
+        2. Whether this is the true initial commit (no parent commit exists yet)
+        3. The git diff content
+        4. The user's draft commit message (optional)
 
         Your task is to analyze these inputs and produce a commit message consisting of:
         - A commit type
@@ -27,7 +28,10 @@ public class Constants
         Choose exactly one commit type:
 
         initial commit
-        - Use when the diff is empty.
+        - Use only when the input states "Is initial commit: true".
+        - A commit with an empty diff on a branch that already has history (e.g. the first
+          commit on a feature branch) is NOT an initial commit; classify it using the other
+          rules instead.
 
         feat
         - Adds a new feature. Aligns with MINOR semantic versioning.

--- a/Src/AiCommitMessage/Utility/GitHelper.cs
+++ b/Src/AiCommitMessage/Utility/GitHelper.cs
@@ -26,17 +26,49 @@ public static class GitHelper
     }
 
     /// <summary>
+    /// Determines whether the commit currently being prepared is the true initial commit,
+    /// i.e. HEAD has no parent because no commits exist yet on the current ref.
+    /// </summary>
+    /// <remarks>
+    /// This is true for a brand new repository before its first commit, and for a freshly
+    /// created orphan branch (<c>git checkout --orphan</c>) before its first commit. It is
+    /// false for the first commit made on a feature branch that was created from a ref that
+    /// already has history, since HEAD there already points to an existing parent commit.
+    /// </remarks>
+    /// <returns><c>true</c> if there is no parent commit; otherwise, <c>false</c>.</returns>
+    public static bool IsInitialCommit()
+    {
+        return IsInitialCommit(null);
+    }
+
+    /// <summary>
+    /// Determines whether the commit currently being prepared is the true initial commit,
+    /// running the underlying git command in the specified working directory.
+    /// </summary>
+    /// <param name="workingDirectory">The repository directory to check, or <c>null</c> to use the current directory.</param>
+    /// <returns><c>true</c> if there is no parent commit; otherwise, <c>false</c>.</returns>
+    internal static bool IsInitialCommit(string workingDirectory)
+    {
+        return string.IsNullOrWhiteSpace(
+            ExecuteGitCommand("rev-parse --verify HEAD", workingDirectory)
+        );
+    }
+
+    /// <summary>
     /// Executes the git command.
     /// </summary>
     /// <param name="arguments">The arguments.</param>
+    /// <param name="workingDirectory">The directory to run the command in, or <c>null</c> to use the current directory.</param>
     /// <returns>System.String.</returns>
-    private static string ExecuteGitCommand(string arguments)
+    private static string ExecuteGitCommand(string arguments, string workingDirectory = null)
     {
         var processStartInfo = new ProcessStartInfo
         {
             FileName = "git",
             Arguments = arguments,
+            WorkingDirectory = workingDirectory ?? string.Empty,
             RedirectStandardOutput = true,
+            RedirectStandardError = true,
             UseShellExecute = false,
             CreateNoWindow = true,
         };
@@ -45,6 +77,7 @@ public static class GitHelper
         process.StartInfo = processStartInfo;
         process.Start();
         var result = process.StandardOutput.ReadToEnd();
+        process.StandardError.ReadToEnd();
         process.WaitForExit();
         return result.Trim();
     }

--- a/Tests/AiCommitMessage.Tests/Services/EnvironmentVariableServiceTests.cs
+++ b/Tests/AiCommitMessage.Tests/Services/EnvironmentVariableServiceTests.cs
@@ -9,6 +9,11 @@ public class EnvironmentVariableServiceTests
     /// <summary>
     /// Tests that setting a User-level environment variable works correctly.
     /// </summary>
+    /// <remarks>
+    /// User/Machine-scoped environment variables have no persistent store on non-Windows
+    /// platforms, so <see cref="Environment.SetEnvironmentVariable(string, string, EnvironmentVariableTarget)"/>
+    /// is a documented no-op there; on those platforms this test only verifies the call succeeds.
+    /// </remarks>
     [Fact]
     public void SetEnvironmentVariable_Should_SetUserVariable_When_TargetIsUser()
     {
@@ -17,16 +22,24 @@ public class EnvironmentVariableServiceTests
             Variable = "TEST_USER_VAR=test_value",
             Target = "User",
         };
+        var originalExitCode = Environment.ExitCode;
 
         try
         {
             EnvironmentVariableService.SetEnvironmentVariable(options);
 
-            var result = Environment.GetEnvironmentVariable(
-                "TEST_USER_VAR",
-                EnvironmentVariableTarget.User
-            );
-            result.Should().Be("test_value");
+            if (OperatingSystem.IsWindows())
+            {
+                var result = Environment.GetEnvironmentVariable(
+                    "TEST_USER_VAR",
+                    EnvironmentVariableTarget.User
+                );
+                result.Should().Be("test_value");
+            }
+            else
+            {
+                Environment.ExitCode.Should().Be(0);
+            }
         }
         finally
         {
@@ -35,12 +48,17 @@ public class EnvironmentVariableServiceTests
                 null,
                 EnvironmentVariableTarget.User
             );
+            Environment.ExitCode = originalExitCode;
         }
     }
 
     /// <summary>
     /// Tests that setting a User-level environment variable works when target is not specified (default).
     /// </summary>
+    /// <remarks>
+    /// See <see cref="SetEnvironmentVariable_Should_SetUserVariable_When_TargetIsUser"/> for why
+    /// this only checks the persisted value on Windows.
+    /// </remarks>
     [Fact]
     public void SetEnvironmentVariable_Should_SetUserVariable_When_TargetIsNotSpecified()
     {
@@ -49,16 +67,24 @@ public class EnvironmentVariableServiceTests
             Variable = "TEST_DEFAULT_VAR=default_value",
             Target = "User",
         };
+        var originalExitCode = Environment.ExitCode;
 
         try
         {
             EnvironmentVariableService.SetEnvironmentVariable(options);
 
-            var result = Environment.GetEnvironmentVariable(
-                "TEST_DEFAULT_VAR",
-                EnvironmentVariableTarget.User
-            );
-            result.Should().Be("default_value");
+            if (OperatingSystem.IsWindows())
+            {
+                var result = Environment.GetEnvironmentVariable(
+                    "TEST_DEFAULT_VAR",
+                    EnvironmentVariableTarget.User
+                );
+                result.Should().Be("default_value");
+            }
+            else
+            {
+                Environment.ExitCode.Should().Be(0);
+            }
         }
         finally
         {
@@ -67,6 +93,7 @@ public class EnvironmentVariableServiceTests
                 null,
                 EnvironmentVariableTarget.User
             );
+            Environment.ExitCode = originalExitCode;
         }
     }
 
@@ -169,6 +196,10 @@ public class EnvironmentVariableServiceTests
     /// <summary>
     /// Tests that target is case-insensitive.
     /// </summary>
+    /// <remarks>
+    /// See <see cref="SetEnvironmentVariable_Should_SetUserVariable_When_TargetIsUser"/> for why
+    /// this only checks the persisted value on Windows.
+    /// </remarks>
     [Theory]
     [InlineData("user")]
     [InlineData("USER")]
@@ -181,16 +212,24 @@ public class EnvironmentVariableServiceTests
             Variable = "TEST_CASE_VAR=case_value",
             Target = target,
         };
+        var originalExitCode = Environment.ExitCode;
 
         try
         {
             EnvironmentVariableService.SetEnvironmentVariable(options);
 
-            var result = Environment.GetEnvironmentVariable(
-                "TEST_CASE_VAR",
-                EnvironmentVariableTarget.User
-            );
-            result.Should().Be("case_value");
+            if (OperatingSystem.IsWindows())
+            {
+                var result = Environment.GetEnvironmentVariable(
+                    "TEST_CASE_VAR",
+                    EnvironmentVariableTarget.User
+                );
+                result.Should().Be("case_value");
+            }
+            else
+            {
+                Environment.ExitCode.Should().Be(0);
+            }
         }
         finally
         {
@@ -199,6 +238,7 @@ public class EnvironmentVariableServiceTests
                 null,
                 EnvironmentVariableTarget.User
             );
+            Environment.ExitCode = originalExitCode;
         }
     }
 }

--- a/Tests/AiCommitMessage.Tests/Services/GenerateCommitMessageServiceTests.cs
+++ b/Tests/AiCommitMessage.Tests/Services/GenerateCommitMessageServiceTests.cs
@@ -429,4 +429,106 @@ public class GenerateCommitMessageServiceTests
         // Assert
         result.Should().Be("Initial commit");
     }
+
+    /// <summary>
+    /// Tests that the prompt sent to the AI model states the commit is the true initial commit
+    /// when the flag is set, so the model is allowed to classify it as such.
+    /// </summary>
+    [Fact]
+    public void BuildFormattedMessage_Should_StateInitialCommitTrue_When_IsInitialCommitIsTrue()
+    {
+        // Act
+        var result = GenerateCommitMessageService.BuildFormattedMessage(
+            "main",
+            string.Empty,
+            "Initial commit",
+            isInitialCommit: true
+        );
+
+        // Assert
+        result.Should().Contain("Is initial commit: true");
+    }
+
+    /// <summary>
+    /// Tests that the prompt sent to the AI model states the commit is NOT the true initial
+    /// commit when the flag is false, e.g. for the first commit on a feature branch that
+    /// already has history.
+    /// </summary>
+    [Fact]
+    public void BuildFormattedMessage_Should_StateInitialCommitFalse_When_IsInitialCommitIsFalse()
+    {
+        // Act
+        var result = GenerateCommitMessageService.BuildFormattedMessage(
+            "feature/test",
+            string.Empty,
+            "Initial commit",
+            isInitialCommit: false
+        );
+
+        // Assert
+        result.Should().Contain("Is initial commit: false");
+    }
+
+    /// <summary>
+    /// Tests that the branch, message, and diff are still included in the prompt alongside
+    /// the initial-commit flag.
+    /// </summary>
+    [Fact]
+    public void BuildFormattedMessage_Should_IncludeBranchMessageAndDiff()
+    {
+        // Act
+        var result = GenerateCommitMessageService.BuildFormattedMessage(
+            "feature/test",
+            "Added new feature",
+            "My draft message",
+            isInitialCommit: false
+        );
+
+        // Assert
+        result.Should().Contain("Branch: feature/test");
+        result.Should().Contain("Original message: My draft message");
+        result.Should().Contain("Git Diff: Added new feature");
+    }
+
+    /// <summary>
+    /// Tests that an explicit <see cref="GenerateCommitMessageOptions.IsInitialCommit"/> override
+    /// of <c>false</c> does not affect the API-disabled fallback path, which never inspects the
+    /// flag, so regular commit message generation keeps working as expected.
+    /// </summary>
+    [Fact]
+    public void GenerateCommitMessage_Should_GenerateRegularMessage_When_IsInitialCommitOverrideIsFalse()
+    {
+        // Arrange
+        Environment.SetEnvironmentVariable(
+            "DOTNET_AICOMMITMESSAGE_DISABLE_API",
+            "true",
+            EnvironmentVariableTarget.Process
+        );
+
+        var options = new GenerateCommitMessageOptions
+        {
+            Branch = "feature/test",
+            Diff = "Some diff",
+            Message = "Add new feature",
+            IsInitialCommit = false,
+        };
+
+        try
+        {
+            // Act
+            var result = _service.GenerateCommitMessage(options);
+
+            // Assert
+            result.Should().Be("Add new feature");
+        }
+        finally
+        {
+            // Cleanup
+            Environment.SetEnvironmentVariable(
+                "DOTNET_AICOMMITMESSAGE_DISABLE_API",
+                null,
+                EnvironmentVariableTarget.Process
+            );
+        }
+    }
 }

--- a/Tests/AiCommitMessage.Tests/Utility/ConstantsTests.cs
+++ b/Tests/AiCommitMessage.Tests/Utility/ConstantsTests.cs
@@ -12,10 +12,11 @@ public class ConstantsTests
         const string expected = """
             You are an expert assistant specialized in generating high-quality Git commit messages.
 
-            You receive three inputs:
+            You receive four inputs:
             1. The branch name
-            2. The git diff content
-            3. The user's draft commit message (optional)
+            2. Whether this is the true initial commit (no parent commit exists yet)
+            3. The git diff content
+            4. The user's draft commit message (optional)
 
             Your task is to analyze these inputs and produce a commit message consisting of:
             - A commit type
@@ -28,7 +29,10 @@ public class ConstantsTests
             Choose exactly one commit type:
 
             initial commit
-            - Use when the diff is empty.
+            - Use only when the input states "Is initial commit: true".
+            - A commit with an empty diff on a branch that already has history (e.g. the first
+              commit on a feature branch) is NOT an initial commit; classify it using the other
+              rules instead.
 
             feat
             - Adds a new feature. Aligns with MINOR semantic versioning.

--- a/Tests/AiCommitMessage.Tests/Utility/GitHelperTests.cs
+++ b/Tests/AiCommitMessage.Tests/Utility/GitHelperTests.cs
@@ -1,0 +1,119 @@
+using System.Diagnostics;
+using AiCommitMessage.Utility;
+using FluentAssertions;
+
+namespace AiCommitMessage.Tests.Utility;
+
+public class GitHelperTests : IDisposable
+{
+    private readonly string _repoPath;
+
+    public GitHelperTests()
+    {
+        _repoPath = Path.Combine(Path.GetTempPath(), "aicm-git-tests-" + Guid.NewGuid());
+        Directory.CreateDirectory(_repoPath);
+        RunGit(_repoPath, "init -q");
+        RunGit(_repoPath, "config user.email test@example.com");
+        RunGit(_repoPath, "config user.name \"Test User\"");
+    }
+
+    public void Dispose()
+    {
+        try
+        {
+            ClearReadOnlyAttributes(_repoPath);
+            Directory.Delete(_repoPath, true);
+        }
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+        {
+            // Best effort cleanup; git marks some object files read-only on Windows.
+        }
+    }
+
+    private static void ClearReadOnlyAttributes(string path)
+    {
+        foreach (var file in Directory.EnumerateFiles(path, "*", SearchOption.AllDirectories))
+        {
+            File.SetAttributes(file, FileAttributes.Normal);
+        }
+    }
+
+    [Fact]
+    public void IsInitialCommit_Should_ReturnTrue_When_RepositoryHasNoCommitsYet()
+    {
+        // Act
+        var result = GitHelper.IsInitialCommit(_repoPath);
+
+        // Assert
+        result.Should().BeTrue();
+    }
+
+    [Fact]
+    public void IsInitialCommit_Should_ReturnFalse_When_HeadAlreadyHasACommit()
+    {
+        // Arrange
+        CommitFile(_repoPath, "file.txt", "content");
+
+        // Act
+        var result = GitHelper.IsInitialCommit(_repoPath);
+
+        // Assert
+        result.Should().BeFalse();
+    }
+
+    [Fact]
+    public void IsInitialCommit_Should_ReturnFalse_When_OnFeatureBranchWithExistingHistory()
+    {
+        // Arrange
+        CommitFile(_repoPath, "file.txt", "content");
+        RunGit(_repoPath, "checkout -q -b feature/test");
+
+        // Act
+        var result = GitHelper.IsInitialCommit(_repoPath);
+
+        // Assert
+        result.Should().BeFalse();
+    }
+
+    [Fact]
+    public void IsInitialCommit_Should_ReturnTrue_When_OnFreshOrphanBranchBeforeFirstCommit()
+    {
+        // Arrange
+        CommitFile(_repoPath, "file.txt", "content");
+        RunGit(_repoPath, "checkout -q --orphan fresh-branch");
+
+        // Act
+        var result = GitHelper.IsInitialCommit(_repoPath);
+
+        // Assert
+        result.Should().BeTrue();
+    }
+
+    private static void CommitFile(string repoPath, string fileName, string content)
+    {
+        File.WriteAllText(Path.Combine(repoPath, fileName), content);
+        RunGit(repoPath, $"add {fileName}");
+        RunGit(repoPath, "commit -q -m \"commit\"");
+    }
+
+    private static void RunGit(string repoPath, string arguments)
+    {
+        var processStartInfo = new ProcessStartInfo
+        {
+            FileName = "git",
+            Arguments = arguments,
+            WorkingDirectory = repoPath,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+            CreateNoWindow = true,
+        };
+
+        using var process = new Process();
+        process.StartInfo = processStartInfo;
+        process.Start();
+        process.StandardOutput.ReadToEnd();
+        process.StandardError.ReadToEnd();
+        process.WaitForExit();
+    }
+}


### PR DESCRIPTION
## 📑 Description
Add support for detecting whether the current commit is truly the initial commit in the repository. This information is included when building the prompt message sent to the AI model, ensuring accurate commit type classification. Refactor the message building logic by introducing a new `BuildFormattedMessage` method to cleanly encapsulate the construction of the formatted message. Added new tests to verify the functionality of initial commit detection and message formatting.


## ✅ Checks
- [X] My pull request adheres to the code style of this project
- [X] My code requires changes to the documentation
- [X] I have updated the documentation as required
- [X] All the tests have passed

## ☢️ Does this introduce a breaking change?
- [ ] Yes
- [X] No

---

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for overriding whether a commit should be treated as the repository’s true initial commit.
  * Commit message generation now includes the initial-commit state in the prompt sent to the assistant.

* **Bug Fixes**
  * Improved initial-commit detection so empty diffs on branches with existing history are no longer mistaken for first commits.

* **Tests**
  * Added/updated tests for prompt formatting, override behavior, and initial-commit detection across multiple repository states.
  * Made environment-variable persistence assertions platform-aware.

* **Chores**
  * Updated supported target frameworks (dropped .NET 9).
  * Updated editor configuration for security scanning.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->